### PR TITLE
Upgrade block.io to > 4.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     ]
   },
   "dependencies": {
-    "block_io": "3.0.0",
+    "block_io": "^4.0.0",
     "bottender": "0.14.34",
     "dotenv": "6.2.0",
     "lodash": "4.17.13",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     ]
   },
   "dependencies": {
-    "block_io": "2.0.0",
+    "block_io": "3.0.0",
     "bottender": "0.14.34",
     "dotenv": "6.2.0",
     "lodash": "4.17.13",

--- a/src/commands/rain.ts
+++ b/src/commands/rain.ts
@@ -5,7 +5,7 @@ import {
   getRandomArrayElements,
 } from '../lib/utils';
 import getChannelMembers from '../lib/members';
-import { sendToAddress } from '../lib/sendToAddresses';
+import { sendToAddress } from '../lib/sendToAddress';
 
 const validateAmount = (amount: number | undefined) => amount && amount > 0;
 
@@ -37,12 +37,12 @@ const rain = async (context: Context, block_io: any, slackClient: any) => {
   console.log('the user id', userId);
   console.log('the members', pickedMembers.join());
 
+  const toLabels = pickedMembers.join();
+  const amountString = new Array(pickedMembers.length)
+    .fill(amount / pickedMembers.length)
+    .join();
   try {
-    await sendToAddress(
-      context.session.user.id,
-      pickedMembers.join(),
-      new Array(pickedMembers.length).fill(amount / pickedMembers.length).join()
-    );
+    await sendToAddress(userId, toLabels, amountString);
 
     return context.sendText(
       `${generateCongrats()} ${pickedMembers.map(

--- a/src/commands/tip.ts
+++ b/src/commands/tip.ts
@@ -1,5 +1,5 @@
 import { generateWow, generateCongrats } from '../lib/utils';
-import { sendToAddress } from '../lib/sendToAddresses';
+import { sendToAddress } from '../lib/sendToAddress';
 import { Context } from '../types/bottender';
 import help from './help';
 

--- a/src/commands/tip.ts
+++ b/src/commands/tip.ts
@@ -1,6 +1,6 @@
 import { generateWow, generateCongrats } from '../lib/utils';
+import { sendToAddress } from '../lib/sendToAddresses';
 import { Context } from '../types/bottender';
-import { withdrawFromLabels } from '../integrations/blockIo';
 import help from './help';
 
 const tip = async (context: Context) => {
@@ -19,11 +19,7 @@ const tip = async (context: Context) => {
   }
 
   try {
-    await withdrawFromLabels({
-      fromLabels: myLabel,
-      toLabel: toLabel,
-      amount: amount,
-    });
+    const data = await sendToAddress(myLabel, toLabel, amount);
 
     await context.sendText(
       `${generateCongrats()} <@${toLabel}> you just received ${amount} doge. ${generateWow()}`

--- a/src/commands/tip.ts
+++ b/src/commands/tip.ts
@@ -19,7 +19,7 @@ const tip = async (context: Context) => {
   }
 
   try {
-    const data = await sendToAddress(myLabel, toLabel, amount);
+    await sendToAddress(myLabel, toLabel, amount);
 
     await context.sendText(
       `${generateCongrats()} <@${toLabel}> you just received ${amount} doge. ${generateWow()}`

--- a/src/commands/tip.ts
+++ b/src/commands/tip.ts
@@ -6,7 +6,6 @@ import help from './help';
 const tip = async (context: Context) => {
   let [, , toLabel, amount] = context.event.text.split(' ');
   if (!toLabel || !amount) {
-    help(context);
     return;
   }
   const myLabel = context.session.user.id;

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,6 @@ bot.onEvent(async (context: Context) => {
 
   if (!command) {
     await context.sendText('Much confused');
-    await commands.help(context);
   } else {
     await command(context, blockIo, slackClient);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ server.listen(3000, async () => {
 
   console.log('Much awesome! server is flipping on port 3000.');
 
-  setInterval(async () => await createAddresses(), 30000);
+  setInterval(async () => await createAddresses(), 600000);
 });
 
 exports.bot = bot;

--- a/src/integrations/blockIo.ts
+++ b/src/integrations/blockIo.ts
@@ -26,7 +26,7 @@ export const getAddressByLabel = (label: string): Promise<any> =>
     );
   });
 
-export const withdrawFromLabels = ({
+export const prepareTransaction = ({
   fromLabels,
   toLabel,
   amount,
@@ -35,17 +35,17 @@ export const withdrawFromLabels = ({
   toLabel: string;
   amount: number | string;
 }): Promise<any> =>
-  new Promise((resolve, reject) => {
-    blockIo.withdraw_from_labels(
-      {
-        from_labels: fromLabels,
-        to_label: toLabel,
-        amount: amount,
-        pin: process.env.BLOCK_IO_SECRET_PIN,
-      },
-      (error: Error | undefined, data: any) => {
-        if (error) return reject(error);
-        resolve(data);
-      }
-    );
+  blockIo.prepare_transaction({
+    from_labels: fromLabels,
+    to_label: toLabel,
+    amount: amount,
+    pin: process.env.BLOCK_IO_SECRET_PIN,
   });
+
+export const createAndSignTransaction = (
+  preparedTransaction: any
+): Promise<any> =>
+  blockIo.create_and_sign_transaction({ data: preparedTransaction });
+
+export const submitTransaction = (signedTransaction: any): Promise<any> =>
+  blockIo.submit_transaction({ transaction_data: signedTransaction });

--- a/src/lib/createAddresses.ts
+++ b/src/lib/createAddresses.ts
@@ -30,6 +30,7 @@ const CreateAddresses = (bot: any, blockIo: any) => {
       bot,
       process.env.GENERAL_CHANNEL_ID!
     );
+    members;
     const existingLabels = addresses.map((a: any) => a.label);
     const addresslessMembers = members.filter(
       (id: any) => !existingLabels.includes(id)

--- a/src/lib/createAddresses.ts
+++ b/src/lib/createAddresses.ts
@@ -25,12 +25,11 @@ const CreateAddresses = (bot: any, blockIo: any) => {
   const createAddresses = async () => {
     const addressesResponse: any = await getAddresses();
     const addresses = addressesResponse.data.addresses;
-    // const {members} = await bot.getAllUserList();
     const members = await getChannelMembers(
       bot,
       process.env.GENERAL_CHANNEL_ID!
     );
-    members;
+
     const existingLabels = addresses.map((a: any) => a.label);
     const addresslessMembers = members.filter(
       (id: any) => !existingLabels.includes(id)

--- a/src/lib/createAddresses.ts
+++ b/src/lib/createAddresses.ts
@@ -37,7 +37,7 @@ const CreateAddresses = (bot: any, blockIo: any) => {
 
     let tasks = [];
     for (let i = 0; i < addresslessMembers.length; i++) {
-      const delay = 500 * i;
+      const delay = 1500 * i;
       tasks.push(
         new Promise(async function(resolve) {
           await new Promise(res => setTimeout(res, delay));

--- a/src/lib/createAddresses.ts
+++ b/src/lib/createAddresses.ts
@@ -35,9 +35,19 @@ const CreateAddresses = (bot: any, blockIo: any) => {
       (id: any) => !existingLabels.includes(id)
     );
 
-    return Promise.all(
-      addresslessMembers.map((id: any) => getNewAddress({ label: id }))
-    );
+    let tasks = [];
+    for (let i = 0; i < addresslessMembers.length; i++) {
+      const delay = 500 * i;
+      tasks.push(
+        new Promise(async function(resolve) {
+          await new Promise(res => setTimeout(res, delay));
+          const result = getNewAddress({ label: addresslessMembers[i] });
+          resolve(result);
+        })
+      );
+    }
+
+    return Promise.all(tasks);
   };
 
   return createAddresses;

--- a/src/lib/sendToAddress.ts
+++ b/src/lib/sendToAddress.ts
@@ -15,13 +15,9 @@ export const sendToAddress = async (
     amount: amount,
   });
 
-  console.log(JSON.stringify(preparedTransaction, null, 2));
-
   const signedTransaction = await createAndSignTransaction(preparedTransaction);
-  console.log(JSON.stringify(signedTransaction, null, 2));
 
   const transactionData = await submitTransaction(signedTransaction);
-  console.log(JSON.stringify(transactionData, null, 2));
 
   return transactionData;
 };

--- a/src/lib/sendToAddresses.ts
+++ b/src/lib/sendToAddresses.ts
@@ -1,0 +1,26 @@
+import {
+  prepareTransaction,
+  createAndSignTransaction,
+  submitTransaction,
+} from '../integrations/blockIo';
+
+export const sendToAddress = async (
+  fromLabels: string,
+  toLabels: string,
+  amount: string
+) => {
+  const preparedTransaction = await prepareTransaction({
+    fromLabels: fromLabels,
+    toLabel: toLabels,
+    amount: amount,
+  });
+  console.log(JSON.stringify(preparedTransaction, null, 2));
+
+  const signedTransaction = await createAndSignTransaction(preparedTransaction);
+  console.log(JSON.stringify(signedTransaction, null, 2));
+
+  const transactionData = await submitTransaction(signedTransaction);
+  console.log(JSON.stringify(transactionData, null, 2));
+
+  return transactionData;
+};

--- a/src/lib/sendToAddresses.ts
+++ b/src/lib/sendToAddresses.ts
@@ -14,6 +14,7 @@ export const sendToAddress = async (
     toLabel: toLabels,
     amount: amount,
   });
+
   console.log(JSON.stringify(preparedTransaction, null, 2));
 
   const signedTransaction = await createAndSignTransaction(preparedTransaction);

--- a/src/types/bottender.ts
+++ b/src/types/bottender.ts
@@ -2,6 +2,7 @@ export interface Context {
   event: {
     text: string;
     isChannelsMessage: boolean;
+    channel: string;
     isGroupsMessage: boolean;
     isText: boolean;
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,6 +87,11 @@
   version "10.0.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.0.8.tgz#37b4d91d4e958e4c2ba0be2b86e7ed4ff19b0858"
 
+"@types/node@10.12.18":
+  version "10.12.18"
+  resolved "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
+  integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
+
 "@types/node@^8.10.30":
   version "8.10.43"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.43.tgz#8d3281a33c92a56038b05d9460a65bc1dcd5735b"
@@ -530,9 +535,12 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
-base-x@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/base-x/-/base-x-1.1.0.tgz#42d3d717474f9ea02207f6d1aa1f426913eeb7ac"
+base-x@^3.0.2:
+  version "3.0.8"
+  resolved "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz#1e1106c2537f0162e8b52474a557ebb09000018d"
+  integrity sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 base@^0.11.1:
   version "0.11.2"
@@ -553,9 +561,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bigi@=1.4.2, bigi@^1.1.0, bigi@^1.4.0:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/bigi/-/bigi-1.4.2.tgz#9c665a95f88b8b08fc05cfd731f561859d725825"
+bech32@^1.1.2:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
+  integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
 binary-extensions@^1.0.0:
   version "1.13.0"
@@ -569,31 +578,80 @@ binary@^0.3.0:
     buffers "~0.1.1"
     chainsaw "~0.1.0"
 
-bitcoinjs-lib@=1.5.6:
-  version "1.5.6"
-  resolved "https://registry.yarnpkg.com/bitcoinjs-lib/-/bitcoinjs-lib-1.5.6.tgz#c628826441a1e58298b7b50ac4d4996231286209"
+bindings@^1.3.0:
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
-    bigi "^1.4.0"
-    bs58check "^1.0.5"
+    file-uri-to-path "1.0.0"
+
+bip174@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/bip174/-/bip174-2.0.1.tgz#39cf8ca99e50ce538fb762589832f4481d07c254"
+  integrity sha512-i3X26uKJOkDTAalYAp0Er+qGMDhrbbh2o93/xiPyAN2s25KrClSpe3VXo/7mNJoqA5qfko8rLS2l3RWZgYmjKQ==
+
+bip32@^2.0.4:
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/bip32/-/bip32-2.0.6.tgz#6a81d9f98c4cd57d05150c60d8f9e75121635134"
+  integrity sha512-HpV5OMLLGTjSVblmrtYRfFFKuQB+GArM0+XP8HGWfJ5vxYBqo+DesvJwOdC2WJ3bCkZShGf0QIfoIpeomVzVdA==
+  dependencies:
+    "@types/node" "10.12.18"
+    bs58check "^2.1.1"
+    create-hash "^1.2.0"
+    create-hmac "^1.1.7"
+    tiny-secp256k1 "^1.1.3"
+    typeforce "^1.11.5"
+    wif "^2.0.6"
+
+bip66@^1.1.0:
+  version "1.1.5"
+  resolved "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz#01fa8748785ca70955d5011217d1b3139969ca22"
+  integrity sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=
+  dependencies:
+    safe-buffer "^5.0.1"
+
+bitcoin-ops@^1.3.0, bitcoin-ops@^1.4.0:
+  version "1.4.1"
+  resolved "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz#e45de620398e22fd4ca6023de43974ff42240278"
+  integrity sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow==
+
+bitcoinjs-lib@^5.1.10:
+  version "5.2.0"
+  resolved "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.2.0.tgz#caf8b5efb04274ded1b67e0706960b93afb9d332"
+  integrity sha512-5DcLxGUDejgNBYcieMIUfjORtUeNWl828VWLHJGVKZCb4zIS1oOySTUr0LGmcqJBQgTBz3bGbRQla4FgrdQEIQ==
+  dependencies:
+    bech32 "^1.1.2"
+    bip174 "^2.0.1"
+    bip32 "^2.0.4"
+    bip66 "^1.1.0"
+    bitcoin-ops "^1.4.0"
+    bs58check "^2.0.0"
     create-hash "^1.1.0"
     create-hmac "^1.1.3"
-    ecurve "^1.0.0"
+    merkle-lib "^2.0.10"
+    pushdata-bitcoin "^1.0.1"
     randombytes "^2.0.1"
-    typeforce "^1.0.0"
+    tiny-secp256k1 "^1.1.1"
+    typeforce "^1.11.3"
+    varuint-bitcoin "^1.0.4"
+    wif "^2.0.1"
 
-block_io@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/block_io/-/block_io-2.0.0.tgz#fab86dae9bc5207755424bff45b6fe89409afd37"
-  integrity sha512-el7RwiICK7+NRXh9eEkk4l5cjV4Qvm9J0UfLyz3dbjFsJYdta7uGTdj/kjZ6whk/tsnQ8qHgomavNqmy1+QGNw==
+block_io@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/block_io/-/block_io-3.0.0.tgz#4d7b3b792ea797a7fa0cea714fc3174b6ddafd49"
+  integrity sha512-mWJTpC4vMzjyIxuq8jIU66o1buzcZx6BJwaoGzqYcdC8L+Xei1YU4yoBPKnJJ/9P9guPUNtNVV/wFKu7ep5yNw==
   dependencies:
-    bigi "=1.4.2"
-    bitcoinjs-lib "=1.5.6"
-    pbkdf2 "=3.0.16"
-    request "=2.88.0"
+    bitcoinjs-lib "^5.1.10"
+    pbkdf2 "^3.1.1"
 
 bluebird@^3.3.4:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+
+bn.js@^4.11.8, bn.js@^4.11.9:
+  version "4.12.0"
+  resolved "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
+  integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
 
 body-parser@1.18.2, body-parser@^1.18.2:
   version "1.18.2"
@@ -705,18 +763,26 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-bs58@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/bs58/-/bs58-3.1.0.tgz#d4c26388bf4804cac714141b1945aa47e5eb248e"
-  dependencies:
-    base-x "^1.1.0"
+brorand@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+  integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
-bs58check@^1.0.5:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/bs58check/-/bs58check-1.3.4.tgz#c52540073749117714fa042c3047eb8f9151cbf8"
+bs58@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
+  integrity sha1-vhYedsNU9veIrkBx9j806MTwpCo=
   dependencies:
-    bs58 "^3.1.0"
+    base-x "^3.0.2"
+
+bs58check@<3.0.0, bs58check@^2.0.0, bs58check@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz#53b018291228d82a5aa08e7d796fdafda54aebfc"
+  integrity sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==
+  dependencies:
+    bs58 "^4.0.0"
     create-hash "^1.1.0"
+    safe-buffer "^5.1.2"
 
 bson@~1.0.4:
   version "1.0.6"
@@ -1117,7 +1183,7 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
-create-hash@^1.1.0, create-hash@^1.1.2:
+create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
   dependencies:
@@ -1127,7 +1193,7 @@ create-hash@^1.1.0, create-hash@^1.1.2:
     ripemd160 "^2.0.1"
     sha.js "^2.4.0"
 
-create-hmac@^1.1.3, create-hmac@^1.1.4:
+create-hmac@^1.1.3, create-hmac@^1.1.4, create-hmac@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
   dependencies:
@@ -1372,13 +1438,6 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-ecurve@^1.0.0:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/ecurve/-/ecurve-1.0.6.tgz#dfdabbb7149f8d8b78816be5a7d5b83fcf6de797"
-  dependencies:
-    bigi "^1.1.0"
-    safe-buffer "^5.0.1"
-
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -1387,6 +1446,19 @@ elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
+
+elliptic@^6.4.0:
+  version "6.5.4"
+  resolved "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
+  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
+  dependencies:
+    bn.js "^4.11.9"
+    brorand "^1.1.0"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.1"
+    inherits "^2.0.4"
+    minimalistic-assert "^1.0.1"
+    minimalistic-crypto-utils "^1.0.1"
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -1622,6 +1694,11 @@ file-type@^4.1.0:
 file-type@^7.5.0:
   version "7.7.1"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-7.7.1.tgz#91c2f5edb8ce70688b9b68a90d931bbb6cb21f65"
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -2007,11 +2084,28 @@ hash-base@^3.0.0:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+hash.js@^1.0.0, hash.js@^1.0.3:
+  version "1.1.7"
+  resolved "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.1"
+
 hasha@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/hasha/-/hasha-3.0.0.tgz#52a32fab8569d41ca69a61ff1a214f8eb7c8bd39"
   dependencies:
     is-stream "^1.0.1"
+
+hmac-drbg@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
+  integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
+  dependencies:
+    hash.js "^1.0.3"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.1"
 
 hoek@4.x.x:
   version "4.2.1"
@@ -2161,6 +2255,11 @@ info-symbol@^0.1.0:
 inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+inherits@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
@@ -3003,6 +3102,11 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
+merkle-lib@^2.0.10:
+  version "2.0.10"
+  resolved "https://registry.npmjs.org/merkle-lib/-/merkle-lib-2.0.10.tgz#82b8dbae75e27a7785388b73f9d7725d0f6f3326"
+  integrity sha1-grjbrnXieneFOItz+ddyXQ9vMyY=
+
 messaging-api-line@^0.6.13:
   version "0.6.16"
   resolved "https://registry.yarnpkg.com/messaging-api-line/-/messaging-api-line-0.6.16.tgz#7cea70fd78aab84df91284f8a6f7be62fa0272e7"
@@ -3126,9 +3230,14 @@ mimic-response@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.0.tgz#df3d3652a73fded6b9b0b24146e6fd052353458e"
 
-minimalistic-assert@^1.0.0:
+minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+
+minimalistic-crypto-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
+  integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
 "minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
@@ -3223,6 +3332,11 @@ mv@~2:
     mkdirp "~0.5.1"
     ncp "~2.0.0"
     rimraf "~2.4.0"
+
+nan@^2.13.2:
+  version "2.15.0"
+  resolved "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
+  integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
 
 nan@^2.3.3:
   version "2.10.0"
@@ -3676,10 +3790,10 @@ path-to-regexp@^1.1.1:
   dependencies:
     isarray "0.0.1"
 
-pbkdf2@=3.0.16:
-  version "3.0.16"
-  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.16.tgz#7404208ec6b01b62d85bf83853a8064f8d9c2a5c"
-  integrity sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==
+pbkdf2@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
+  integrity sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==
   dependencies:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
@@ -3876,6 +3990,13 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+pushdata-bitcoin@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz#15931d3cd967ade52206f523aa7331aef7d43af7"
+  integrity sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=
+  dependencies:
+    bitcoin-ops "^1.3.0"
 
 q@^1.1.2:
   version "1.5.1"
@@ -4102,7 +4223,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@=2.88.0, request@^2.88.0:
+request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -4754,6 +4875,17 @@ timed-out@^4.0.0, timed-out@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
+tiny-secp256k1@^1.1.1, tiny-secp256k1@^1.1.3:
+  version "1.1.6"
+  resolved "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.6.tgz#7e224d2bee8ab8283f284e40e6b4acb74ffe047c"
+  integrity sha512-FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==
+  dependencies:
+    bindings "^1.3.0"
+    bn.js "^4.11.8"
+    create-hmac "^1.1.7"
+    elliptic "^6.4.0"
+    nan "^2.13.2"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -4860,9 +4992,10 @@ type-is@^1.5.5, type-is@^1.6.14, type-is@~1.6.15, type-is@~1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
-typeforce@^1.0.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/typeforce/-/typeforce-1.12.0.tgz#ca40899919f1466d7819e37be039406beb912a2e"
+typeforce@^1.11.3, typeforce@^1.11.5:
+  version "1.18.0"
+  resolved "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz#d7416a2c5845e085034d70fcc5b6cc4a90edbfdc"
+  integrity sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==
 
 typescript@3.3.1:
   version "3.3.1"
@@ -5022,6 +5155,13 @@ validate-npm-package-name@^3.0.0:
   dependencies:
     builtins "^1.0.3"
 
+varuint-bitcoin@^1.0.4:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz#e76c138249d06138b480d4c5b40ef53693e24e92"
+  integrity sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==
+  dependencies:
+    safe-buffer "^5.1.1"
+
 vary@^1.0.0, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
@@ -5087,6 +5227,13 @@ widest-line@^2.0.0:
   resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-2.0.0.tgz#0142a4e8a243f8882c0233aa0e0281aa76152273"
   dependencies:
     string-width "^2.1.1"
+
+wif@^2.0.1, wif@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz#08d3f52056c66679299726fade0d432ae74b4704"
+  integrity sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=
+  dependencies:
+    bs58check "<3.0.0"
 
 window-size@^1.1.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -615,7 +615,7 @@ bitcoin-ops@^1.3.0, bitcoin-ops@^1.4.0:
   resolved "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz#e45de620398e22fd4ca6023de43974ff42240278"
   integrity sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow==
 
-bitcoinjs-lib@^5.1.10:
+bitcoinjs-lib@^5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.2.0.tgz#caf8b5efb04274ded1b67e0706960b93afb9d332"
   integrity sha512-5DcLxGUDejgNBYcieMIUfjORtUeNWl828VWLHJGVKZCb4zIS1oOySTUr0LGmcqJBQgTBz3bGbRQla4FgrdQEIQ==
@@ -636,13 +636,13 @@ bitcoinjs-lib@^5.1.10:
     varuint-bitcoin "^1.0.4"
     wif "^2.0.1"
 
-block_io@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/block_io/-/block_io-3.0.0.tgz#4d7b3b792ea797a7fa0cea714fc3174b6ddafd49"
-  integrity sha512-mWJTpC4vMzjyIxuq8jIU66o1buzcZx6BJwaoGzqYcdC8L+Xei1YU4yoBPKnJJ/9P9guPUNtNVV/wFKu7ep5yNw==
+block_io@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.npmjs.org/block_io/-/block_io-4.0.3.tgz#51618ea2da50a9f4b959260de755b6df9a2c8dcb"
+  integrity sha512-2BeCYFVVi5s45jvhPe/dvY0Si2y6gNNo0bMgfE5z4sIn2/L6KY8Jt3rh+p+yU7UXp3ZUkxHHGZxEFEYBeMrc9A==
   dependencies:
-    bitcoinjs-lib "^5.1.10"
-    pbkdf2 "^3.1.1"
+    bitcoinjs-lib "^5.2.0"
+    pbkdf2 "^3.1.2"
 
 bluebird@^3.3.4:
   version "3.5.1"
@@ -3790,7 +3790,7 @@ path-to-regexp@^1.1.1:
   dependencies:
     isarray "0.0.1"
 
-pbkdf2@^3.1.1:
+pbkdf2@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
   integrity sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==


### PR DESCRIPTION
This PR updates block.io to 4.x.x. With the update, the commands `tip` and `rain` had to be refactored using a single method `sendToAddress`.